### PR TITLE
s/Log/Logf/ typo

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -365,7 +365,7 @@ func TestPureGo(t *testing.T) {
 	case "true":
 		purego = true
 	default:
-		t.Log("Not performed: %q", s)
+		t.Logf("Not performed: %q", s)
 	}
 
 	if g, e := puregoDecode(), purego; g != e {


### PR DESCRIPTION
I'm not sure what the switch in TestPureGo is meant to accomplish (what's the point of printing *pureGo when it's empty?) anyway. So I'm not really suggesting to merge that change, just pointing out the typo.
